### PR TITLE
Enable inference using CPU

### DIFF
--- a/model/Swin-transformer-focalloss/pre_transformer.py
+++ b/model/Swin-transformer-focalloss/pre_transformer.py
@@ -63,7 +63,8 @@ def positional_encoding_1d(position, d_model):
     angle_rads[:, 0::2] = np.sin(angle_rads[:, 0::2])
     angle_rads[:, 1::2] = np.cos(angle_rads[:, 1::2])
     pos_encoding = angle_rads[np.newaxis, ...]
-    return torch.from_numpy(pos_encoding.astype('float32')).cuda()
+    device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    return torch.from_numpy(pos_encoding.astype('float32')).to(device)
 
 
 class FeedForward(nn.Module):

--- a/model/Swin-transformer-focalloss/run_ocsr_on_images.py
+++ b/model/Swin-transformer-focalloss/run_ocsr_on_images.py
@@ -176,6 +176,8 @@ class FocalLossModelInference:
             smiles = converter.decode(deep_smiles)
         except deepsmiles.DecodeError:
             smiles = False
+        except IndexError:
+            smiles = False
         return smiles
 
 


### PR DESCRIPTION
When running the inference of the focal loss model on a device without a suitable GPU, I got the following error:

```
Traceback (most recent call last):
  File "run_ocsr_on_images.py", line 283, in <module>
    main()
  File "run_ocsr_on_images.py", line 270, in main
    inference = FocalLossModelInference()
  File "run_ocsr_on_images.py", line 34, in __init__
    self.decoder = self.build_decoder()
  File "run_ocsr_on_images.py", line 79, in build_decoder
    tag=False)
  File "/path/to/SwinOCSR/model/Swin-transformer-focalloss/pre_transformer.py", line 290, in __init__
    self.encoder = TransformerEncode(dim=dim, ff_dim=ff_dim, num_head=num_head, encoder_num_layer=encoder_num_layer, dropout=drop_rate, max_len=max_len)
  File "/path/to/SwinOCSR/model/Swin-transformer-focalloss/pre_transformer.py", line 180, in __init__
    self.pos_encoding_1d = positional_encoding_1d(max_len, dim)
  File "/path/to/SwinOCSR/model/Swin-transformer-focalloss/pre_transformer.py", line 66, in positional_encoding_1d
    return torch.from_numpy(pos_encoding.astype('float32')).cuda()
  File "/path/to/SwinOCSR/lib/python3.7/site-packages/torch/cuda/__init__.py", line 166, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

This is fixed easily by changing the following line (66) in pre_transformer.py:
`return torch.from_numpy(pos_encoding.astype('float32')).cuda()`
to:
```
device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
return torch.from_numpy(pos_encoding.astype('float32')).to(device)
```

This way, the user can use the tool without needing a CUDA device, but if a CUDA device is available, it is used.